### PR TITLE
Avoid bloating previous author's contribution stats

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -116,7 +116,7 @@ git config --global user.name "Archive Bot"
 git add -A
 if [[ "$delete_history" == "true" ]]
 then
-	git commit --amend -m "Update archive."
+	git commit --amend --reset-author -m "Update archive."
 	# Cleanup loose objects
 	git gc
 else


### PR DESCRIPTION
Otherwise GitHub counts each force-push of an amended commit as a contribution by the original author, which may lead to hundreds and thousands of "fake" contributions provided that action typically runs multiple times a day.